### PR TITLE
moving register endpoint into auth

### DIFF
--- a/ABOUT.md
+++ b/ABOUT.md
@@ -299,16 +299,16 @@ In all, the following API endpoints are provided:
 | ------ | -------------- | ---------------------------- | --------------- | -------------------------------------------- |
 | GET    | /api/users     | `userControllers.listUsers ` | `User.list()`   | Get the list of all users                    |
 | GET    | /api/users/:id | `userControllers.showUser  ` | `User.find()`   | Get a specific user by id                    |
-| POST   | /api/users     | `userControllers.createUser` | `User.create()` | Create a new user and set the cookie userId  |
 | PATCH  | /api/users/:id | `userControllers.updateUser` | `User.update()` | Update the username of a specific user by id |
 
 **Authentication Routes**:
 
-| Method | Path        | Controller                   | Model Method            | Description                                            |
-| ------ | ----------- | ---------------------------- | ----------------------- | ------------------------------------------------------ |
-| GET    | /api/me     | `authControllers.showMe`     | `User.find()`           | Get the current logged in user based on the cookie     |
-| POST   | /api/login  | `authControllers.loginUser`  | `User.findByUsername()` | Log in to an existing user and set cookie userId value |
-| DELETE | /api/logout | `authControllers.logoutUser` | None                    | Log the current user out (delete the cookie)           |
+| Method | Path        | Controller                     | Model Method            | Description                                            |
+| ------ | ----------- | ------------------------------ | ----------------------- | ------------------------------------------------------ |
+| POST   | /api/users  | `authControllers.registerUser` | `User.create()`         | Create a new user and set the cookie userId            |
+| POST   | /api/login  | `authControllers.loginUser`    | `User.findByUsername()` | Log in to an existing user and set cookie userId value |
+| GET    | /api/me     | `authControllers.showMe`       | `User.find()`           | Get the current logged in user based on the cookie     |
+| DELETE | /api/logout | `authControllers.logoutUser`   | None                    | Log the current user out (delete the cookie)           |
 
 ### The Login Flow
 

--- a/frontend/src/adapters/auth-adapter.js
+++ b/frontend/src/adapters/auth-adapter.js
@@ -1,6 +1,10 @@
 import { fetchHandler, getPostOptions, deleteOptions } from "../utils/fetchingUtils";
 
-const baseUrl = '/api';
+const baseUrl = '/api/auth';
+
+export const registerUser = async ({ username, password }) => {
+  return fetchHandler(`${baseUrl}/register`, getPostOptions({ username, password }))
+};
 
 export const checkForLoggedInUser = async () => {
   const [data] = await fetchHandler(`${baseUrl}/me`);

--- a/frontend/src/adapters/user-adapter.js
+++ b/frontend/src/adapters/user-adapter.js
@@ -1,12 +1,8 @@
 // These functions all take in a body and return an options object
 // with the provided body and the remaining options
-import { fetchHandler, getPostOptions, getPatchOptions } from "../utils/fetchingUtils";
+import { fetchHandler, getPatchOptions } from "../utils/fetchingUtils";
 
 const baseUrl = '/api/users';
-
-export const createUser = async ({ username, password }) => {
-  return fetchHandler(baseUrl, getPostOptions({ username, password }))
-};
 
 // For this one adapter, if an error occurs, we handle it here by printing
 // the error and return an empty array

--- a/frontend/src/pages/SignUp.jsx
+++ b/frontend/src/pages/SignUp.jsx
@@ -1,7 +1,7 @@
 import { useContext, useState } from "react";
 import { useNavigate, Navigate, Link } from "react-router-dom";
 import CurrentUserContext from "../contexts/current-user-context";
-import { createUser } from "../adapters/user-adapter";
+import { registerUser } from "../adapters/auth-adapter";
 
 // Controlling the sign up form is a good idea because we want to add (eventually)
 // more validation and provide real time feedback to the user about usernames and passwords
@@ -22,7 +22,7 @@ export default function SignUpPage() {
     setErrorText('');
     if (!username || !password) return setErrorText('Missing username or password');
 
-    const [user, error] = await createUser({ username, password });
+    const [user, error] = await registerUser({ username, password });
     if (error) return setErrorText(error.message);
 
     setCurrentUser(user);

--- a/server/controllers/userControllers.js
+++ b/server/controllers/userControllers.js
@@ -1,16 +1,6 @@
 const { isAuthorized } = require('../utils/auth-utils');
 const User = require('../models/User');
 
-exports.createUser = async (req, res) => {
-  const { username, password } = req.body;
-
-  // TODO: check if username is taken, and if it is what should you return?
-  const user = await User.create(username, password);
-  req.session.userId = user.id;
-
-  res.send(user);
-};
-
 exports.listUsers = async (req, res) => {
   const users = await User.list();
   res.send(users);

--- a/server/index.js
+++ b/server/index.js
@@ -28,9 +28,10 @@ app.use(express.static(path.join(__dirname, '../frontend/dist'))); // Serve stat
 // Auth Routes
 ///////////////////////////////
 
-app.get('/api/me', authControllers.showMe);
-app.post('/api/login', authControllers.loginUser);
-app.delete('/api/logout', authControllers.logoutUser);
+app.post('/api/auth/register', authControllers.registerUser);
+app.post('/api/auth/login', authControllers.loginUser);
+app.get('/api/auth/me', authControllers.showMe);
+app.delete('/api/auth/logout', authControllers.logoutUser);
 
 
 
@@ -38,7 +39,6 @@ app.delete('/api/logout', authControllers.logoutUser);
 // User Routes
 ///////////////////////////////
 
-app.post('/api/users', userControllers.createUser);
 
 // These actions require users to be logged in (authentication)
 // Express lets us pass a piece of middleware to run for a specific endpoint


### PR DESCRIPTION
Semantically, registering a new user is part of the authentication flow. If this `user.create()` method were used as part of an admin dashboard where an admin was creating users, then `POST /api/users` would be appropriate. However, since a user is registering a user for themselves, it should be part of the authentication handlers.